### PR TITLE
Checkout registration doesn't do anything

### DIFF
--- a/Resources/views/Frontend/Checkout/Step/security.html.twig
+++ b/Resources/views/Frontend/Checkout/Step/security.html.twig
@@ -35,7 +35,7 @@
     <div class="span6">
         <div class="well">
             <h3>{{ 'sylius.checkout.security.new_customer'|trans }}</h3>
-                <form action="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" method="post" novalidate>
+                <form action="{{ path('fos_user_registration_register') }}" method="post" novalidate>
                 <fieldset>
                     {{ form_widget(registration_form) }}
                 </fieldset>


### PR DESCRIPTION
Checkout registration form doesn't do anything when form action is sylius_checkout_forward. Setting action to fos_user_registration_register.
