### PR TITLE
rename output for css assets

### DIFF
--- a/Resources/views/Backend/layout.html.twig
+++ b/Resources/views/Backend/layout.html.twig
@@ -12,7 +12,7 @@
 
         {% block stylesheets %}
             <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.css" type="text/css" />
-            {% stylesheets output='assets/compiled/backend.css' filter='cssrewrite'
+            {% stylesheets output='assets/compiled/sylius_compiled_backend.css' filter='cssrewrite'
                 '@SyliusWebBundle/Resources/assets/css/blueimp-gallery.css'
                 '@SyliusWebBundle/Resources/assets/css/datepicker3.css'
                 '@SyliusWebBundle/Resources/assets/css/backend.css'


### PR DESCRIPTION
In a production environment, when trying to dump the assets, for some reason if the name of the output is backend.css, it is overwritten by something and the blueimp gallery is lost.
In the dev environment that doesn't happen.
I think the problem is it is overwritten by something else being called backend.css (maybe the very same backend.css that's parsed).
Renaming the output to something else fixed it for me.
