### PR TITLE
Locale and Currency menu shouldn't be renderd when only 1 exists

### DIFF
--- a/Menu/FrontendMenuBuilder.php
+++ b/Menu/FrontendMenuBuilder.php
@@ -181,19 +181,26 @@ class FrontendMenuBuilder extends MenuBuilder
     }
 
     /**
-     * Builds frontend currency menu.
+     * Builds frontend currency menu if we have more then 1 currency to display.
      *
      * @return ItemInterface
      */
     public function createCurrencyMenu()
     {
+        $currencies = $this->currencyProvider->getAvailableCurrencies();
+
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
                 'class' => 'nav nav-pills'
             )
         ));
 
-        foreach ($this->currencyProvider->getAvailableCurrencies() as $currency) {
+        if (count($currencies) <= 1) {
+            $menu->isDisplayed(false);
+            return $menu;
+        }
+
+        foreach ($currencies as $currency) {
             $code = $currency->getCode();
 
             $menu->addChild($code, array(

--- a/Menu/LocaleMenuBuilder.php
+++ b/Menu/LocaleMenuBuilder.php
@@ -55,19 +55,26 @@ class LocaleMenuBuilder extends MenuBuilder
     }
 
     /**
-     * Builds frontend locale menu.
+     * Builds frontend locale menu if more then one language is defined.
      *
      * @return ItemInterface
      */
     public function createMenu()
     {
+        $locales = $this->localeProvider->getAvailableLocales();
+
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
                 'class' => 'nav nav-pills'
             )
         ));
 
-        foreach ($this->localeProvider->getAvailableLocales() as $locale) {
+        if (count($locales) <= 1) {
+            $menu->isDisplayed(false);
+            return $menu;
+        }
+
+        foreach ($locales as $locale) {
             $code = $locale->getCode();
 
             $menu->addChild($code, array(


### PR DESCRIPTION
It's weird the menu's are shown when there is no option to cycle through. Currency is shown in many places so you don't need a weird sign on the top to tell you the current currency. Same goes with the language.